### PR TITLE
chore(ci): Upgrade workflow to non-deprecated runtimes

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -22,8 +22,8 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-python@v2
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
         with:
           python-version: '3.7'
       - name: Run Pytest
@@ -38,14 +38,14 @@ jobs:
       needs: test
       steps:
         - name: Login to GitHub Container Registry
-          uses: docker/login-action@v1.10.0
+          uses: docker/login-action@v2
           with:
             registry: ghcr.io
             username: ${{ github.actor }}
             password: ${{ secrets.GITHUB_TOKEN }}
             logout: true
         - name: Docker build and push test to ghcr.io
-          uses: docker/build-push-action@v2
+          uses: docker/build-push-action@v4
           with:
             file: Dockerfile.gh
             push: true
@@ -54,8 +54,8 @@ jobs:
       runs-on: ubuntu-latest
       needs: github_docker_build_publish_test
       steps:
-        - uses: actions/checkout@v2
-        - uses: actions/setup-python@v2
+        - uses: actions/checkout@v3
+        - uses: actions/setup-python@v4
           with:
             python-version: '3.7'
         - name: Test biased_lang:test image
@@ -68,14 +68,14 @@ jobs:
     needs: github_test
     steps:
       - name: Login to GitHub Container Registry
-        uses: docker/login-action@v1.10.0
+        uses: docker/login-action@v2
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
           logout: true
       - name: Docker build and push prod to ghcr.io
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v4
         with:
           file: Dockerfile.gh
           push: true
@@ -85,14 +85,14 @@ jobs:
     needs: test
     steps:
       - name: Login to GitHub Container Registry
-        uses: docker/login-action@v1.10.0
+        uses: docker/login-action@v2
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
           logout: true
       - name: Docker build and push gitlab image to ghcr.io
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v4
         with:
           file: Dockerfile.gl
           push: true

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ biased_lang:
     runs-on: ubuntu-latest
     name: Detecting Biased Language
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - id: biased-lang-linter
         uses: splunk/biased-lang-linter@main
         continue-on-error: true
@@ -47,7 +47,7 @@ jobs:
     runs-on: ubuntu-latest
     name: Detecting Biased Language
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - id: biased-lang-linter
         uses: splunk/biased-lang-linter@main
         continue-on-error: true


### PR DESCRIPTION
Hi!

The main workflow is using a deprecated Node.js 12 runtime. Github have announced that everyone should move away from the deprecated Node.js runtime as of [this](https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/) blogpost.